### PR TITLE
feat: update product name prefix for microk8s cluster

### DIFF
--- a/product.go
+++ b/product.go
@@ -78,7 +78,7 @@ func ProductFromContext(c *clientcmdapi.Context, cl *clientcmdapi.Cluster) Produ
 		// As of KinD 0.6.0, KinD uses a context name prefix
 		// https://github.com/kubernetes-sigs/kind/issues/1060
 		return ProductKIND
-	} else if strings.HasPrefix(cn, "microk8s-cluster") {
+	} else if strings.HasPrefix(cn, "microk8s") {
 		return ProductMicroK8s
 	} else if strings.HasPrefix(cn, "api-crc-testing") {
 		return ProductCRC

--- a/product_test.go
+++ b/product_test.go
@@ -50,6 +50,9 @@ func TestProductFromContext(t *testing.T) {
 	microK8sContext := &api.Context{
 		Cluster: "microk8s-cluster",
 	}
+	microK8sContextPrefixWithoutCluster := &api.Context{
+		Cluster: "microk8s",
+	}
 	microK8sPrefixContext := &api.Context{
 		Cluster: "microk8s-cluster-dev-cluster-1",
 	}
@@ -101,6 +104,7 @@ func TestProductFromContext(t *testing.T) {
 		{ProductGKE, gkeContext, defaultCluster},
 		{ProductKIND, kind5Context, defaultCluster},
 		{ProductMicroK8s, microK8sContext, defaultCluster},
+		{ProductMicroK8s, microK8sContextPrefixWithoutCluster, defaultCluster},
 		{ProductMicroK8s, microK8sPrefixContext, defaultCluster},
 		{ProductCRC, crcContext, defaultCluster},
 		{ProductCRC, crcPrefixContext, defaultCluster},

--- a/product_test.go
+++ b/product_test.go
@@ -50,7 +50,7 @@ func TestProductFromContext(t *testing.T) {
 	microK8sContext := &api.Context{
 		Cluster: "microk8s-cluster",
 	}
-	microK8sContextPrefixWithoutCluster := &api.Context{
+	microK8sContextNoClusterSuffix := &api.Context{
 		Cluster: "microk8s",
 	}
 	microK8sPrefixContext := &api.Context{
@@ -104,7 +104,7 @@ func TestProductFromContext(t *testing.T) {
 		{ProductGKE, gkeContext, defaultCluster},
 		{ProductKIND, kind5Context, defaultCluster},
 		{ProductMicroK8s, microK8sContext, defaultCluster},
-		{ProductMicroK8s, microK8sContextPrefixWithoutCluster, defaultCluster},
+		{ProductMicroK8s, microK8sContextNoClusterSuffix, defaultCluster},
 		{ProductMicroK8s, microK8sPrefixContext, defaultCluster},
 		{ProductCRC, crcContext, defaultCluster},
 		{ProductCRC, crcPrefixContext, defaultCluster},


### PR DESCRIPTION
Updated product identification supporting cluster names starting with microk8s, resolving issue [#4300](https://github.com/tilt-dev/tilt/issues/4300).